### PR TITLE
Sync with completed koans

### DIFF
--- a/src/main/java/net/thornydev/mybatis/koan/koan02/Koan02.java
+++ b/src/main/java/net/thornydev/mybatis/koan/koan02/Koan02.java
@@ -57,7 +57,7 @@ public class Koan02 {
     // TODO: fill in "?" generic unknown placeholders
     Map<?,?> map = null;
 
-    assertEquals(Integer.valueOf(1), map.get("country_id"));
+    assertEquals(1, ((Number) getFromMap(map, "country_id") ).intValue());
     assertEquals("Afghanistan", map.get("country"));
     assertNotNull(map.get("last_update"));
   }
@@ -67,7 +67,7 @@ public class Koan02 {
     // TODO: call "selectOneAsMapDynamic" mapped query, passing in id 33 as param
     Map<Object,Object> map = null;
 
-    assertEquals(Integer.valueOf(33), map.get("country_id"));
+    assertEquals(33, ((Number)getFromMap(map, "country_id")).intValue());
     assertEquals("Finland", map.get("country"));
     assertNotNull(map.get("last_update"));
   }
@@ -82,7 +82,17 @@ public class Koan02 {
     // TODO: fill in "?" generic unknown placeholders
     final Map<?,?> map109 = lmap.get(0);
 
-    assertEquals(Integer.valueOf(109), map109.get("country_id"));
+    assertEquals(109, ((Number)getFromMap(map109, "country_id")).intValue());
     assertEquals("Zambia", map109.get("country"));
+  }
+
+  /* ---[ Helper method ]--- */
+
+  private Object getFromMap(Map<String, Object> map, String key) {
+    if (map.containsKey(key.toLowerCase())) {
+      return map.get(key.toLowerCase());
+    } else {
+      return map.get(key.toUpperCase());
+    }
   }
 }


### PR DESCRIPTION
I've identified a mismatch from the koans to the completed koans. The assertions on the completed Koan 02 deal correctly with minor datatype differences (Short instead of Integer) and case-sensitiveness, but the koan itself does not. The end result is that the user needs to change the assertions in order to make the tests pass.

This PR fixes that.

I'll keep this branch active and "fix" other koans as I do them, in case you decide to merge it back.
